### PR TITLE
Homebrew audit fixes for formulae

### DIFF
--- a/Aliases/msodbcsql@13.1
+++ b/Aliases/msodbcsql@13.1
@@ -1,0 +1,1 @@
+../Formula/msodbcsql.rb

--- a/Aliases/mssql-tools@14.0
+++ b/Aliases/mssql-tools@14.0
@@ -1,0 +1,1 @@
+../Formula/mssql-tools.rb

--- a/Formula/msodbcsql.rb
+++ b/Formula/msodbcsql.rb
@@ -1,43 +1,32 @@
 class Msodbcsql < Formula
   desc "ODBC Driver for Microsoft(R) SQL Server(R)"
   homepage "https://msdn.microsoft.com/en-us/library/mt654048(v=sql.1).aspx"
-  url "http://download.microsoft.com/download/4/9/5/495639C0-79E4-45A7-B65A-B264071C3D9A/msodbcsql-13.1.9.0.tar.gz"
-  version "13.1.9.0"
+  url "https://download.microsoft.com/download/4/9/5/495639C0-79E4-45A7-B65A-B264071C3D9A/msodbcsql-13.1.9.0.tar.gz"
   sha256 "902b6850882825a42614baa1de88456416465d15aeb828331eb1aac069e02576"
 
   option "without-registration", "Don't register the driver in odbcinst.ini"
 
-  def caveats; <<-EOS.undent
-    If you installed this formula with the registration option (default), you'll
-    need to manually remove [ODBC Driver 13 for SQL Server] section from
-    odbcinst.ini after the formula is uninstalled. This can be done by executing
-    the following command:
-        odbcinst -u -d -n "ODBC Driver 13 for SQL Server"
-    EOS
-  end
-
   depends_on "unixodbc"
   depends_on "openssl"
 
-  def check_eula_acceptance
-    if ENV["ACCEPT_EULA"] != "y" and ENV["ACCEPT_EULA"] != "Y" then
+  def check_eula_acceptance?
+    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "https://aka.ms/odbc131eula and found in"
       puts "/usr/local/share/doc/msodbcsql/LICENSE.txt . By entering 'YES',"
       puts "you indicate that you accept the license terms."
       puts ""
-      while true do
+      loop do
         puts "Do you accept the license terms? (Enter YES or NO)"
         accept_eula = STDIN.gets.chomp
-        if accept_eula then
-          if accept_eula == "YES" then
-            break
-          elsif accept_eula == "NO" then
+        if accept_eula
+          break if accept_eula == "YES"
+          if accept_eula == "NO"
             puts "Installation terminated: License terms not accepted."
             return false
           else
             puts "Please enter YES or NO"
-          end  
+          end
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
@@ -46,13 +35,11 @@ class Msodbcsql < Formula
         end
       end
     end
-    return true
+    true
   end
 
   def install
-    if !check_eula_acceptance
-      return false
-    end
+    return false unless check_eula_acceptance?
 
     chmod 0444, "lib/libmsodbcsql.13.dylib"
     chmod 0444, "share/msodbcsql/resources/en_US/msodbcsqlr13.rll"
@@ -61,11 +48,27 @@ class Msodbcsql < Formula
     chmod 0644, "share/doc/msodbcsql/LICENSE.txt"
     chmod 0644, "share/doc/msodbcsql/RELEASE_NOTES"
 
-    cp_r ".", "#{prefix}"
+    cp_r ".", prefix.to_s
 
-    if !build.without? "registration"
-        system "odbcinst -u -d -n \"ODBC Driver 13 for SQL Server\""
-        system "odbcinst -i -d -f ./odbcinst.ini"
+    if build.with? "registration"
+      system "odbcinst", "-u", "-d", "-n", "\"ODBC Driver 13 for SQL Server\""
+      system "odbcinst", "-i", "-d", "-f", "./odbcinst.ini"
+    end
+  end
+
+  def caveats; <<-EOS.undent
+    If you installed this formula with the registration option (default), you'll
+    need to manually remove [ODBC Driver 13 for SQL Server] section from
+    odbcinst.ini after the formula is uninstalled. This can be done by executing
+    the following command:
+        odbcinst -u -d -n "ODBC Driver 13 for SQL Server"
+  EOS
+  end
+
+  test do
+    if build.with? "registration"
+      out = shell_output("#{Formula["unixodbc"].opt_bin}/odbcinst -q -d")
+      assert_match "ODBC Driver 13 for SQL Server", out
     end
   end
 end

--- a/Formula/mssql-tools.rb
+++ b/Formula/mssql-tools.rb
@@ -9,20 +9,19 @@ class MssqlTools < Formula
   depends_on "openssl"
   depends_on "msodbcsql"
 
-  def check_eula_acceptance
-    if ENV["ACCEPT_EULA"] != "y" and ENV["ACCEPT_EULA"] != "Y" then
+  def check_eula_acceptance?
+    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "http://go.microsoft.com/fwlink/?LinkId=746949 and found in"
       puts "/usr/local/share/doc/mssql-tools/LICENSE.txt . By entering 'YES',"
       puts "you indicate that you accept the license terms."
       puts ""
-      while true do
+      loop do
         puts "Do you accept the license terms? (Enter YES or NO)"
         accept_eula = STDIN.gets.chomp
-        if accept_eula then
-          if accept_eula == "YES" then
-            break
-          elsif accept_eula == "NO" then
+        if accept_eula
+          break if accept_eula == "YES"
+          if accept_eula == "NO"
             puts "Installation terminated: License terms not accepted."
             return false
           else
@@ -36,13 +35,11 @@ class MssqlTools < Formula
         end
       end
     end
-    return true
+    true
   end
 
   def install
-    if !check_eula_acceptance
-      return false
-    end
+    return false unless check_eula_acceptance?
 
     chmod 0444, "bin/sqlcmd"
     chmod 0444, "bin/bcp"
@@ -53,6 +50,13 @@ class MssqlTools < Formula
     chmod 0644, "usr/share/doc/mssql-tools/LICENSE.txt"
     chmod 0644, "usr/share/doc/mssql-tools/THIRDPARTYNOTICES.txt"
 
-    cp_r ".", "#{prefix}"
+    cp_r ".", prefix.to_s
+  end
+
+  test do
+    out = shell_output("#{bin}/sqlcmd -?")
+    assert_match "Microsoft (R) SQL Server Command Line Tool", out
+    out = shell_output("#{bin}/bcp -v")
+    assert_match "BCP - Bulk Copy Program for Microsoft SQL Server", out
   end
 end


### PR DESCRIPTION
Hi,

Some formulae fix ups to meet current `brew audit` output (Homebrew v1.3.6-8-g15096e7):

```
$ brew audit --strict --online msodbcsql
microsoft/mssql-release/msodbcsql:
  * C: 1: col 1: A `test do` test block should be added
  * C: 19: col 3: `depends_on` (line 19) should be put before `caveats` (line 10)
  * C: 23: col 34: Use `&&` instead of `and`.
  * C: 23: col 64: Do not use `then` for multi-line `if`.
  * C: 29: col 7: Use `Kernel#loop` for infinite loops.
  * W: 29: col 13: Literal `true` appeared in a condition.
  * C: 29: col 18: Do not use `do` with multi-line `while`.
  * C: 32: col 24: Do not use `then` for multi-line `if`.
  * C: 33: col 11: Avoid more than 3 levels of block nesting.
  * C: 33: col 35: Do not use `then` for multi-line `if`.
  * C: 35: col 37: Do not use `then` for multi-line `elsif`.
  * C: 40: col 14: Trailing whitespace detected.
  * C: 49: col 5: Redundant `return` detected.
  * C: 52: col 3: `install` (line 52) should be put before `caveats` (line 10)
  * C: 53: col 5: Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
  * C: 53: col 5: Favor `unless` over `if` for negative conditions.
  * C: 64: col 15: Prefer `to_s` over string interpolation.
  * C: 66: col 5: Favor `unless` over `if` for negative conditions.
  * C: 67: col 5: Use 2 (not 4) spaces for indentation.
  * Incorrect file permissions (755): chmod 644 /usr/local/Homebrew/Library/Taps/microsoft/homebrew-mssql-release/Formula/msodbcsql.rb
  * Formula has other versions so create a versioned alias:
      cd /usr/local/Homebrew/Library/Taps/microsoft/homebrew-mssql-release/Aliases
      ln -s ../Formula/msodbcsql.rb msodbcsql@13.1
  * Stable: version 13.1.9.0 is redundant with version scanned from URL
  * Stable: The URL http://download.microsoft.com/download/4/9/5/495639C0-79E4-45A7-B65A-B264071C3D9A/msodbcsql-13.1.9.0.tar.gz should use HTTPS rather than HTTP
  * Don't negate 'build.without?': use 'build.with?'
  * Use `system "odbcinst", "-u", "-d", "-n", "\"` instead of `system "odbcinst -u -d -n \"` 
  * Use `system "odbcinst", "-i", "-d", "-f", "./odbcinst.ini"` instead of `system "odbcinst -i -d -f ./odbcinst.ini"` 
Error: 26 problems in 1 formula
```
```
$ brew audit --strict --online mssql-tools
microsoft/mssql-release/mssql-tools:
  * C: 1: col 1: A `test do` test block should be added
  * C: 13: col 34: Use `&&` instead of `and`.
  * C: 13: col 64: Do not use `then` for multi-line `if`.
  * C: 19: col 7: Use `Kernel#loop` for infinite loops.
  * W: 19: col 13: Literal `true` appeared in a condition.
  * C: 19: col 18: Do not use `do` with multi-line `while`.
  * C: 22: col 24: Do not use `then` for multi-line `if`.
  * C: 23: col 11: Avoid more than 3 levels of block nesting.
  * C: 23: col 35: Do not use `then` for multi-line `if`.
  * C: 25: col 37: Do not use `then` for multi-line `elsif`.
  * C: 39: col 5: Redundant `return` detected.
  * C: 43: col 5: Favor modifier `if` usage when having a single-line body. Another good alternative is the usage of control flow `&&`/`||`.
  * C: 43: col 5: Favor `unless` over `if` for negative conditions.
  * C: 56: col 15: Prefer `to_s` over string interpolation.
  * C: 58: col 4: Final newline missing.
  * File should end with a newline
Error: 16 problems in 1 formula
```