### PR TITLE
Use HOMEBREW_ACCEPT_EULA as env variable for Homebrew 1.4+ compatibility

### DIFF
--- a/Formula/msodbcsql.rb
+++ b/Formula/msodbcsql.rb
@@ -11,7 +11,7 @@ class Msodbcsql < Formula
   depends_on "openssl"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "https://aka.ms/odbc131eula and found in"
       puts "/usr/local/share/doc/msodbcsql/LICENSE.txt . By entering 'YES',"
@@ -31,7 +31,7 @@ class Msodbcsql < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/msodbcsql17.rb
+++ b/Formula/msodbcsql17.rb
@@ -11,7 +11,7 @@ class Msodbcsql17 < Formula
   depends_on "openssl"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "https://aka.ms/odbc172eula and found in"
       puts "/usr/local/share/doc/msodbcsql17/LICENSE.txt . By entering 'YES',"
@@ -32,7 +32,7 @@ class Msodbcsql17 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/msodbcsql17@17.0.1.1.rb
+++ b/Formula/msodbcsql17@17.0.1.1.rb
@@ -13,7 +13,7 @@ class Msodbcsql17AT17011 < Formula
   depends_on "openssl"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "https://aka.ms/odbc170eula and found in"
       puts "/usr/local/share/doc/msodbcsql17/LICENSE.txt . By entering 'YES',"
@@ -34,7 +34,7 @@ class Msodbcsql17AT17011 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/msodbcsql17@17.1.0.1.rb
+++ b/Formula/msodbcsql17@17.1.0.1.rb
@@ -13,7 +13,7 @@ class Msodbcsql17AT17101 < Formula
   depends_on "openssl"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "https://aka.ms/odbc170eula and found in"
       puts "/usr/local/share/doc/msodbcsql17/LICENSE.txt . By entering 'YES',"
@@ -34,7 +34,7 @@ class Msodbcsql17AT17101 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/msodbcsql17@17.2.0.1.rb
+++ b/Formula/msodbcsql17@17.2.0.1.rb
@@ -13,7 +13,7 @@ class Msodbcsql17AT17201 < Formula
   depends_on "openssl"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "https://aka.ms/odbc172eula and found in"
       puts "/usr/local/share/doc/msodbcsql17/LICENSE.txt . By entering 'YES',"
@@ -34,7 +34,7 @@ class Msodbcsql17AT17201 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/msodbcsql@13.1.7.0.rb
+++ b/Formula/msodbcsql@13.1.7.0.rb
@@ -13,7 +13,7 @@ class MsodbcsqlAT13170 < Formula
   depends_on "openssl"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "https://aka.ms/odbc131eula and found in"
       puts "/usr/local/share/doc/msodbcsql/LICENSE.txt . By entering 'YES',"
@@ -33,7 +33,7 @@ class MsodbcsqlAT13170 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/msodbcsql@13.1.9.2.rb
+++ b/Formula/msodbcsql@13.1.9.2.rb
@@ -13,7 +13,7 @@ class MsodbcsqlAT13192 < Formula
   depends_on "openssl"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "https://aka.ms/odbc131eula and found in"
       puts "/usr/local/share/doc/msodbcsql/LICENSE.txt . By entering 'YES',"
@@ -33,7 +33,7 @@ class MsodbcsqlAT13192 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/mssql-tools.rb
+++ b/Formula/mssql-tools.rb
@@ -10,7 +10,7 @@ class MssqlTools < Formula
   depends_on "msodbcsql17"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "http://go.microsoft.com/fwlink/?LinkId=746949 and found in"
       puts "/usr/local/share/doc/mssql-tools/LICENSE.txt . By entering 'YES',"
@@ -30,7 +30,7 @@ class MssqlTools < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/mssql-tools@14.0.6.0.rb
+++ b/Formula/mssql-tools@14.0.6.0.rb
@@ -10,7 +10,7 @@ class MssqlToolsAT14060 < Formula
   depends_on "msodbcsql"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "http://go.microsoft.com/fwlink/?LinkId=746949 and found in"
       puts "/usr/local/share/doc/mssql-tools/LICENSE.txt . By entering 'YES',"
@@ -30,7 +30,7 @@ class MssqlToolsAT14060 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/mssql-tools@17.0.1.1.rb
+++ b/Formula/mssql-tools@17.0.1.1.rb
@@ -10,7 +10,7 @@ class MssqlToolsAT17011 < Formula
   depends_on "msodbcsql17"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "http://go.microsoft.com/fwlink/?LinkId=746949 and found in"
       puts "/usr/local/share/doc/mssql-tools/LICENSE.txt . By entering 'YES',"
@@ -30,7 +30,7 @@ class MssqlToolsAT17011 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/mssql-tools@17.1.0.1.rb
+++ b/Formula/mssql-tools@17.1.0.1.rb
@@ -10,7 +10,7 @@ class MssqlToolsAT17101 < Formula
   depends_on "msodbcsql17"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "http://go.microsoft.com/fwlink/?LinkId=746949 and found in"
       puts "/usr/local/share/doc/mssql-tools/LICENSE.txt . By entering 'YES',"
@@ -30,7 +30,7 @@ class MssqlToolsAT17101 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end

--- a/Formula/mssql-tools@17.2.0.1.rb
+++ b/Formula/mssql-tools@17.2.0.1.rb
@@ -10,7 +10,7 @@ class MssqlToolsAT17201 < Formula
   depends_on "msodbcsql17"
 
   def check_eula_acceptance?
-    if ENV["ACCEPT_EULA"] != "y" && ENV["ACCEPT_EULA"] != "Y"
+    if ENV["HOMEBREW_ACCEPT_EULA"] != "y" && ENV["HOMEBREW_ACCEPT_EULA"] != "Y"
       puts "The license terms for this product can be downloaded from"
       puts "http://go.microsoft.com/fwlink/?LinkId=746949 and found in"
       puts "/usr/local/share/doc/mssql-tools/LICENSE.txt . By entering 'YES',"
@@ -30,7 +30,7 @@ class MssqlToolsAT17201 < Formula
         else
           puts "Installation terminated: Could not prompt for license acceptance."
           puts "If you are performing an unattended installation, you may set"
-          puts "ACCEPT_EULA to Y to indicate your acceptance of the license terms."
+          puts "HOMEBREW_ACCEPT_EULA to Y to indicate your acceptance of the license terms."
           return false
         end
       end


### PR DESCRIPTION
Changes in Homebrew from v1.4.0 onwards sanitise the environment that is
available to formulae.  Only specific env variables are passed through so `ACCEPT_EULA` no longer gets passed through.  The simplest way of getting the option through is to prefix the
environment variable with `HOMEBREW_`.

I have a PR open with the core of Homebrew to explain the env variable
filtering in detail but you can read the details in the meantime in the
PR at
https://github.com/Homebrew/brew/blob/7f8d90740a228a582330df684518274712ec04c9/docs/Formula-Cookbook.md#using-environment-variables