### PR TITLE
Use direct HTTPS link to download mssql-tools@14

### DIFF
--- a/Formula/mssql-tools@14.0.6.0.rb
+++ b/Formula/mssql-tools@14.0.6.0.rb
@@ -1,7 +1,7 @@
 class MssqlToolsAT14060 < Formula
   desc "Sqlcmd and Bcp for Microsoft(R) SQL Server(R)"
   homepage "https://msdn.microsoft.com/en-us/library/ms162773.aspx"
-  url "https://go.microsoft.com/fwlink/?linkid=848963"
+  url "https://download.microsoft.com/download/F/D/1/FD16AA69-F27D-440E-A15A-6C521A1972E6/mssql-tools-14.0.6.0.tar.gz"
   version "14.0.6.0"
   sha256 "b31cfe98ff3c8f60a98fd02a1ebbe7cf7a2172320239adccd073ad3870786bf9"
 


### PR DESCRIPTION
When attempting to install `mssql-tools@14.0.6.0` the download URL starts with https:// but it redirects to an insecure http:// URL which fails to download when Homebrew is configured with
`HOMEBREW_NO_INSECURE_REDIRECT=1`.  

This change makes the formula match the others and their download
locations.  A separate security report has been made about the https to http
redirection/downgrade.

The following is the log output (note that I'm using my fix from https://github.com/Microsoft/homebrew-mssql-release/pull/26 so the automated install works; but I could have just as easily typed "YES" to each EULA):

```
$ HOMEBREW_ACCEPT_EULA=Y brew install mssql-tools@14.0.6.0
==> Installing mssql-tools@14.0.6.0 from microsoft/mssql-release
==> Installing dependencies for microsoft/mssql-release/mssql-tools@14.0.6.0: msodbcsql
==> Installing microsoft/mssql-release/mssql-tools@14.0.6.0 dependency: msodbcsql
==> Downloading https://download.microsoft.com/download/4/9/5/495639C0-79E4-45A7-B65A-B264071C3D9A/msodbcsql-13.1.9.2.tar.gz
Already downloaded: /Users/local/Library/Caches/Homebrew/downloads/8f7c6834a87f6929b76418db93542d73395a5e5b9099c57d13a49e5991a8edab--msodbcsql-13.1.9.2.tar.gz
==> odbcinst -u -d -n "ODBC Driver 13 for SQL Server"
==> odbcinst -i -d -f ./odbcinst.ini
==> Caveats
If you installed this formula with the registration option (default), you'll
need to manually remove [ODBC Driver 13 for SQL Server] section from
odbcinst.ini after the formula is uninstalled. This can be done by executing
the following command:
    odbcinst -u -d -n "ODBC Driver 13 for SQL Server"
==> Summary
🍺  /usr/local/Cellar/msodbcsql/13.1.9.2: 9 files, 2.6MB, built in 5 seconds
==> Installing microsoft/mssql-release/mssql-tools@14.0.6.0
==> Downloading https://go.microsoft.com/fwlink/?linkid=848963
==> Downloading from http://download.microsoft.com/download/F/D/1/FD16AA69-F27D-440E-A15A-6C521A1972E6/mssql-tools-14.0.6.0.tar.gz
HTTPS to HTTP redirect detected & HOMEBREW_NO_INSECURE_REDIRECT is set.
Error: An exception occurred within a child process:
  DownloadError: Failed to download resource "mssql-tools@14.0.6.0"
Download failed: https://go.microsoft.com/fwlink/?linkid=848963
```